### PR TITLE
Include sha-bang in the deploy script

### DIFF
--- a/before_deploy.sh
+++ b/before_deploy.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 cd www
 mynt gen -f _site
 cp -a _site/. ../


### PR DESCRIPTION
So that when the script fails, it will report the error,
rather than failing silently.